### PR TITLE
update: response of modification_agent

### DIFF
--- a/app/agents/main_agent.py
+++ b/app/agents/main_agent.py
@@ -287,6 +287,8 @@ class MainAgent(BaseAgent):
                 topic_response = TopicResponse(
                     id=topic.Id,
                     title=topic.Title,
+                    eN_Title=topic.Title,
+                    abbreviation=getattr(topic, "Abbreviation", None),
                     description=topic.Description,
                     objectives=topic.Objectives,
                     supervisor_id=topic.SupervisorId,
@@ -301,7 +303,7 @@ class MainAgent(BaseAgent):
                     "success": True,
                     "data": {
                         "topic_id": topic.Id,
-                        "topic": topic_response.dict()
+                        "topic": topic_response.dict(by_alias=True)
                     }
                 }
                 

--- a/app/api/topic_router.py
+++ b/app/api/topic_router.py
@@ -37,7 +37,8 @@ modification_agent = TopicModificationAgent()
 rubric_agent = CheckRubricAgent()
 
 class DuplicateAdvancedRequest(BaseModel):
-    eN_Title: str = Field(..., description="English title")
+    eN_Title: Optional[str] = Field(None, description="English title")
+    title: Optional[str] = Field(None, description="Alias for English title")
     abbreviation: Optional[str] = None
     vN_title: Optional[str] = None
     problem: Optional[str] = None
@@ -73,7 +74,7 @@ async def check_duplicate_advanced(
         t0 = time.time()
         # Normalize request to new schema regardless of legacy/new input
         if isinstance(req, DuplicateAdvancedRequest):
-            en_title = req.eN_Title or ""
+            en_title = (req.eN_Title or req.title or "")
             vn_title = req.vN_title or ""
             problem = req.problem or ""
             context_val = req.context or ""

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from typing import Optional, List, Dict, Any
 from datetime import datetime
 from enum import Enum
@@ -132,6 +132,16 @@ class SubmissionResubmitResponse(BaseModel):
 
 class TopicRequest(BaseModel):
     """Schema for topic submission request."""
+    eN_Title: Optional[str] = Field(
+        None,
+        description="English title duplicate for systems expecting EN_Title",
+        example="AI-Powered Library Management System"
+    )
+    abbreviation: Optional[str] = Field(
+        None,
+        description="Short abbreviation derived from the title",
+        example="APLMS"
+    )
     title: str = Field(
         ..., 
         max_length=500, 
@@ -164,25 +174,31 @@ class TopicRequest(BaseModel):
         example="Nghiên cứu và phát triển hệ thống quản lý thư viện thông minh sử dụng AI để nhận diện sách, gợi ý cá nhân hóa và IoT để theo dõi tài sản"
     )
     category_id: Optional[int] = Field(
-        None, 
+        None,
         description="Topic category ID",
-        example=2
+        example=2,
+        alias="categoryId",
     )
     supervisor_id: int = Field(
-        ..., 
+        ...,
         description="Supervisor user ID",
-        example=1
+        example=1,
+        alias="supervisorId",
     )
     semester_id: int = Field(
-        ..., 
+        ...,
         description="Semester ID",
-        example=1
+        example=1,
+        alias="semesterId",
     )
     max_students: int = Field(
         default=1, 
         description="Maximum number of students",
         example=2
     )
+
+    # Pydantic v2 config: allow population by field name when aliases exist
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class TopicVersionResponse(BaseModel):
@@ -209,19 +225,21 @@ class TopicResponse(BaseModel):
     """Schema for topic response."""
     id: int
     title: str
+    eN_Title: str
+    abbreviation: Optional[str]
     description: Optional[str]
     objectives: Optional[str]
-    supervisor_id: int
-    category_id: Optional[int]
-    semester_id: int
+    supervisor_id: int = Field(alias="supervisorId")
+    category_id: Optional[int] = Field(alias="categoryId")
+    semester_id: int = Field(alias="semesterId")
     max_students: int
     is_approved: bool
     created_at: datetime
     latest_version: Optional[TopicVersionResponse] = None
     approved_version: Optional[TopicVersionResponse] = None
 
-    class Config:
-        from_attributes = True
+    # Pydantic v2 config
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 class DuplicateCheckResult(BaseModel):

--- a/app/services/topic_service.py
+++ b/app/services/topic_service.py
@@ -222,6 +222,8 @@ class TopicService:
                 topic_response = TopicResponse(
                     id=topic.Id,
                     title=topic.Title,
+                    eN_Title=topic.Title,
+                    abbreviation=getattr(topic, "Abbreviation", None),
                     description=topic.Description,
                     objectives=topic.Objectives,
                     supervisor_id=topic.SupervisorId,
@@ -238,7 +240,7 @@ class TopicService:
                     "success": True,
                     "data": {
                         "topic_id": topic.Id,
-                        "topic": topic_response.dict()
+                        "topic": topic_response.dict(by_alias=True)
                     }
                 }
                 
@@ -276,6 +278,8 @@ class TopicService:
                 return TopicResponse(
                     id=topic.Id,
                     title=topic.Title,
+                    eN_Title=topic.Title,
+                    abbreviation=getattr(topic, "Abbreviation", None),
                     description=topic.Description,
                     objectives=topic.Objectives,
                     supervisor_id=topic.SupervisorId,
@@ -317,6 +321,8 @@ class TopicService:
                     TopicResponse(
                         id=topic.Id,
                         title=topic.Title,
+                        eN_Title=topic.Title,
+                        abbreviation=getattr(topic, "Abbreviation", None),
                         description=topic.Description,
                         objectives=topic.Objectives,
                         supervisor_id=topic.SupervisorId,
@@ -359,6 +365,8 @@ class TopicService:
                     TopicResponse(
                         id=topic.Id,
                         title=topic.Title,
+                        eN_Title=topic.Title,
+                        abbreviation=getattr(topic, "Abbreviation", None),
                         description=topic.Description,
                         objectives=topic.Objectives,
                         supervisor_id=topic.SupervisorId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `eN_Title` and `abbreviation` across schemas/agents, switch responses to alias-aware serialization, and relax API input to accept `title` as English title.
> 
> - **Schemas**:
>   - Add `eN_Title` and `abbreviation` to `TopicRequest` and `TopicResponse`; set alias fields for `supervisorId`, `categoryId`, `semesterId` with Pydantic v2 `populate_by_name` and `from_attributes`.
> - **Agents**:
>   - `TopicModificationAgent`: ensure `eN_Title` and `abbreviation` in outputs, update prompt/JSON spec to require them, add `_generate_abbreviation`, and serialize responses with `by_alias=True`.
>   - `MainAgent`: when creating topics, include `eN_Title`/`abbreviation` in `TopicResponse` and return `topic_response.dict(by_alias=True)`.
> - **API**:
>   - `DuplicateAdvancedRequest`: make `eN_Title` optional and add optional `title` fallback; normalize using `eN_Title` or `title`.
> - **Services**:
>   - Include `eN_Title`/`abbreviation` in `TopicResponse` construction across retrieval/search methods and serialize with `by_alias=True` where returned.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c8ac2011f81c1d48e786a7b54b262b5cca9f2c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->